### PR TITLE
Remove net-istio webhook certs secret from propagation policy

### DIFF
--- a/karmada-policies/pp-net-istio.yaml
+++ b/karmada-policies/pp-net-istio.yaml
@@ -23,10 +23,6 @@ spec:
     - apiVersion: v1
       kind: ConfigMap
       name: config-istio
-    # Secrets
-    - apiVersion: v1
-      kind: Secret
-      name: net-istio-webhook-certs
     # Istio Custom Resources
     - apiVersion: networking.istio.io/v1beta1
       kind: Gateway


### PR DESCRIPTION
## Summary
- remove the net-istio webhook certs Secret from the pp-net-istio propagation policy

## Testing
- `ruby -ryaml -e "YAML.load_file('karmada-policies/pp-net-istio.yaml'); puts 'YAML parsed successfully'"`


------
https://chatgpt.com/codex/tasks/task_e_689198eb15948332a68db03690844140